### PR TITLE
Bugfix/#38 unsafe assignment to innerhtml

### DIFF
--- a/src/javascript/enhancements/animeRequests.js
+++ b/src/javascript/enhancements/animeRequests.js
@@ -66,6 +66,7 @@ function removeUnknownUsers(node) {
 
         // add user note if own request
         if (profileLink.length > 0) {
+            // Workaround to avoid innerHTML because of #38, see https://devtidbits.com/2017/12/06/quick-fix-the-unsafe_var_assignment-warning-in-javascript/
             let parser = new DOMParser();
             let parsedDocument = parser.parseFromString(profileData, 'text/html');
 


### PR DESCRIPTION
Those changes should fix the warning of using `innerHTML` to assign HTML content. Clearing elements with `element.innerHTML = ''` still is fine, have looked this up.

Results also still look good and don´t cause errors:
![200911_20-35-49-501 Requests_-_Aniwatch_-_Google_Chrome](https://user-images.githubusercontent.com/8461282/92960973-cb24fc00-f46e-11ea-9157-0672fc015b5a.png)
