### PR TITLE
#52 Remove href attribute instead of clearing it

### DIFF
--- a/src/javascript/enhancements/quickSearch.js
+++ b/src/javascript/enhancements/quickSearch.js
@@ -57,7 +57,7 @@ function handleQuickSearch(event) {
         linkElement.click();
 
         // clean up afterwards
-        linkElement.href = '';
+        linkElement.removeAttribute('href');
         quickSearchElement.value = '';
     }
 }


### PR DESCRIPTION
This will fix #52. The empty `href`-attribute made the website navigate to the *home* page.