### PR TITLE
#54 Avoid quick search hotkey if input is focused

### DIFF
--- a/src/javascript/enhancements/quickSearch.js
+++ b/src/javascript/enhancements/quickSearch.js
@@ -64,7 +64,12 @@ function handleQuickSearch(event) {
 
 function handleSearchForShiftF(event) {
     if (helper.isShiftPressed) {
-        if (event.key === 'F') {
+        // check if some kind of input is focused already; we then prevent our hotkey
+        if (document.activeElement instanceof HTMLInputElement || document.activeElement.isContentEditable) {
+            return;
+        }
+        
+        if (event.code === 'KeyF') {
             event.preventDefault();
             document.getElementById(quickSearchID).focus();
         }


### PR DESCRIPTION
So, I decided to just add a check if the `document.activeElement` is some kind of input ot contentEditable and prevent the hotkey as a quickfix, as there are issues with extending the Hotkey to `Ctrl` + `Shift` + `F`.
The behaviour might be improved in future if we found a better solution.