### PR TITLE
#90 Add styles to fix icon position for room creator

### DIFF
--- a/src/stylesheets/aniwatchplus.scss
+++ b/src/stylesheets/aniwatchplus.scss
@@ -2,4 +2,5 @@
 @import './vars/colors';
 
 // enhancements
-@import './enhancements/lists.scss';
+@import './enhancements/lists';
+@import './enhancements/watch2gether';

--- a/src/stylesheets/enhancements/_watch2gether.scss
+++ b/src/stylesheets/enhancements/_watch2gether.scss
@@ -1,0 +1,6 @@
+.material-icons {
+    // Fix icon position for room creator
+    &[aria-label="Room creator"] {
+        vertical-align: text-top;
+    }
+}


### PR DESCRIPTION
The difference is pretty small (only by *1px* if I saw it correctly) but it makes a big different to the appearance (at least if I can trust my eyes).
Left: before
Right: after
![i1](https://user-images.githubusercontent.com/8461282/97106982-3fd19400-16c5-11eb-88db-5259e5361780.png)

Here is a zoomed in version with a red line which shows the text-top line, where you also can see the old (left) version wasn´t aligned properly:
![image](https://user-images.githubusercontent.com/8461282/97107003-67286100-16c5-11eb-9aa1-b1e8154c3a9c.png)
